### PR TITLE
fix(esphome): add libusb and cache-relative toolchain prefixes for esp-idf

### DIFF
--- a/apps/esphome/Dockerfile
+++ b/apps/esphome/Dockerfile
@@ -22,7 +22,9 @@ ENV \
     HOME="/config" \
     PLATFORMIO_CORE_DIR=/cache/pio \
     ESPHOME_BUILD_PATH=/cache/build \
-    ESPHOME_DATA_DIR=/cache/data
+    ESPHOME_DATA_DIR=/cache/data \
+    ESPHOME_ESP_IDF_PREFIX=/cache/idf \
+    ESPHOME_SDK_NRF_PREFIX=/cache/sdk-nrf
 
 USER root
 WORKDIR /app
@@ -38,6 +40,7 @@ RUN \
         iputils-ping \
         libcairo2 \
         libmagic1 \
+        libusb-1.0-0 \
         openssh-client \
         patch \
     && pip install uv \


### PR DESCRIPTION
## Problem
Device compiles fail on 2026.7.0:
```
openocd: error while loading shared libraries: libusb-1.0.so.0: cannot open shared object file
ERROR ESP-IDF 5.5.4 framework installation - failed
```

ESPHome 2026.7.0 manages the ESP-IDF toolchain itself (no longer via PlatformIO). Its bundled openocd links against libusb-1.0, which `python:3.13-slim` doesn't ship — the official esphome base image installs `libusb-1.0-0` explicitly.

Additionally, the toolchain prefix defaults to `$HOME/.cache` → `/config/.cache/esphome/idf`, so the multi-GB toolchain (re-downloaded on every failed install) fills the config volume instead of the cache volume.

## Fix
- install `libusb-1.0-0`
- set `ESPHOME_ESP_IDF_PREFIX=/cache/idf` and `ESPHOME_SDK_NRF_PREFIX=/cache/sdk-nrf` (matches what upstream's docker entrypoint does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)