### PR TITLE
feat(petkit-local): add petkit-local 1.1.0

### DIFF
--- a/apps/petkit-local/Dockerfile
+++ b/apps/petkit-local/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/python:3.12-alpine
+ARG VERSION
+ARG TARGETARCH
+
+# renovate: datasource=github-releases depName=AlexxIT/go2rtc
+ARG GO2RTC_VERSION=v1.9.14
+
+ENV PYTHONPATH=/opt/petkit-local \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_ROOT_USER_ACTION=ignore
+
+WORKDIR /opt/petkit-local
+
+# ffmpeg remuxes device camera clips; go2rtc republishes the camera stream as
+# RTSP. Both degrade gracefully on camera-less devices.
+RUN apk add --no-cache catatonit ffmpeg \
+    && wget -qO- "https://github.com/alex-so-3/petkit-local/archive/refs/tags/${VERSION}.tar.gz" | tar xz -C /tmp \
+    && pip install -r "/tmp/petkit-local-${VERSION#v}/addon/requirements.txt" \
+    && cp -r "/tmp/petkit-local-${VERSION#v}/addon/petkit_local" ./petkit_local \
+    && rm -rf "/tmp/petkit-local-${VERSION#v}" \
+    && wget -qO /usr/local/bin/go2rtc "https://github.com/AlexxIT/go2rtc/releases/download/${GO2RTC_VERSION}/go2rtc_linux_${TARGETARCH}" \
+    && chmod +x /usr/local/bin/go2rtc \
+    && mkdir -p /data /media/petkit \
+    && chown -R 1000:1000 /data /media/petkit
+
+USER 1000
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 8080 8099 8443 9000
+
+ENTRYPOINT ["/usr/bin/catatonit", "--", "python3", "-m", "petkit_local.main"]

--- a/apps/petkit-local/container_test.go
+++ b/apps/petkit-local/container_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/home-operations/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("quay.io/nklmilojevic/petkit-local:rolling")
+	testhelpers.TestHTTPEndpoint(t, ctx, image, testhelpers.HTTPTestConfig{Port: "8099"}, nil)
+}

--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "petkit-local"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-tags depName=alex-so-3/petkit-local
+  default = "v1.1.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/alex-so-3/petkit-local"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
## Description

Adds [petkit-local](https://github.com/alex-so-3/petkit-local) — a local stand-in for PetKit's cloud (litter box, feeder, fountain), built from the upstream source tarball at the pinned tag on `python:3.12-alpine` with `ffmpeg` and a pinned `go2rtc` binary.

- Runs as UID 1000, `catatonit` as PID 1, no `--ha-addon` self-configuration — all config via CLI args.
- Renovate tracks upstream via `github-tags` (no GitHub releases published) and `go2rtc` via `github-releases`.
- Test boots the container with defaults and asserts the web panel answers on 8099.

Verified locally: image builds, `go test` passes, and a smoke run with production flags brings up the device API (8080), MQTT TLS listener (8443), media bucket (9000) and panel (8099).

🤖 Generated with [Claude Code](https://claude.com/claude-code)