### PR TITLE
chore(petkit-local): bump fork build to v1.6.0-nkl.2

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -6,7 +6,7 @@ variable "APP" {
 
 variable "VERSION" {
   // renovate: datasource=github-tags depName=nklmilojevic/petkit-local
-  default = "v1.6.0-nkl.1"
+  default = "v1.6.0-nkl.2"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps the petkit-local fork build to `v1.6.0-nkl.2`, adding two D4H fixes on top of nkl.1:

- **Desiccant Days Left** — wired into the consumable-countdown framework (Reset Desiccant records the date, counts down from a 30-day pack life).
- **Battery Installed** — derived from the device's `batV` backup-battery voltage (the D4H never sends `batteryPower`).

Full addon test suite green. Produces `quay.io/nklmilojevic/petkit-local:1.6.0-nkl.2`.