### PR TITLE
fix(petkit-local): pin fork build to v1.6.0-nkl.3 (stop renovate reverting)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -5,8 +5,12 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  // renovate: datasource=github-tags depName=nklmilojevic/petkit-local
-  default = "v1.6.0"
+  // Pinned by hand — renovate intentionally does NOT manage this. The fork
+  // still carries upstream's plain `v1.6.0` tag, and semver ranks 1.6.0 ABOVE
+  // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
+  // straight back to unpatched upstream (it did, once). Bump this by hand when
+  // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
+  default = "v1.6.0-nkl.3"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Renovate ranked the fork's plain `v1.6.0` tag above the `1.6.0-nkl.N` prereleases and reverted VERSION to `v1.6.0` = unpatched upstream, wiping the D4H fixes on the cluster. This drops the renovate annotation, pins nkl.3 by hand.

**nkl.3** adds the camera-feeder **cloud-storage service block** (root-caused by RE of the device's ctrl/cloud binaries over root SSH) so the D4H stages+uploads event clips to the local bucket instead of `media:0`.