### PR TITLE
chore(petkit-local): bump to v1.6.0-nkl.4 (feed-clip upload)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.3"
+  default = "v1.6.0-nkl.4"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
nkl.4: seed feedPicture/eatVideo/upload so camera feeders actually stage+upload feed clips (second gate found by RE of ctrl).