### PR TITLE
chore(petkit-local): bump to v1.6.0-nkl.5 (Enable Feed Video runtime push)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.4"
+  default = "v1.6.0-nkl.5"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Adds an Enable Feed Video button pushing feedPicture/eatVideo/upload via property.set at runtime (the boot-time settings seed doesn't apply mid-session).