### PR TITLE
chore(petkit-local): bump to v1.6.0-nkl.6 (bucket cert SAN)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.5"
+  default = "v1.6.0-nkl.6"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Final upload gate: the bucket TLS cert now includes the api_url host (LB IP) in its SAN, so the device's cloud binary accepts it and completes the media PUT.