### PR TITLE
chore(petkit-local): bump to v1.6.0-nkl.7 (bucket-cert urlparse fix)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.6"
+  default = "v1.6.0-nkl.7"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Fixes the nkl.6 NameError that made the bucket fall back to plain HTTP; now the TLS cert regenerates with the LB IP in SAN so the device completes the media upload.