### PR TITLE
chore(petkit-local): bump fork build to v1.6.0-nkl.8 (camera_enable fix)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.7"
+  default = "v1.6.0-nkl.8"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps the petkit-local fork build to **v1.6.0-nkl.8**.

## Fix: `camera_enable` never set → no feed/eat media uploaded

RE of the D4H `ctrl` binary + a captured real-cloud `dev_multi_config` response showed the camera-schedule field `cameraMultiNew` must be an array of **schedule objects** `{enable, rpt, time}` — the shape the real PetKit cloud returns and the one the fork's litter path already uses. The fork was sending a bare `[[0,1440]]` pair, which the firmware parser (`pk_parse_cameraMultiNew_func`) rejects (`parse cameraMultiNew fail, data null`). With the parse failing, `camera_enable` is never set, the camera encoder stays off (`camera not enable, not update the compare picture`), and every feed/eat reports `media:0` with nothing to upload.

Fork fix (nklmilojevic/petkit-local@v1.6.0-nkl.8): emit the all-day/all-week object form so `camera_enable=1` and feed snapshots + eat clips record and upload to the local bucket.

- Fork tag: `v1.6.0-nkl.8`
- Verified the generated `cameraMultiNew` string matches the captured real-cloud response byte-for-byte.