### PR TITLE
chore(petkit-local): bump fork build to v1.6.0-nkl.9 (bucket cert TLS-verify fix)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.8"
+  default = "v1.6.0-nkl.9"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps the petkit-local fork build to **v1.6.0-nkl.9**.

## Fix: cloud media upload failed TLS verification

The `cloud` media uploader (libcurl + OpenSSL 1.0.0, `VERIFYHOST=2`) rejected the bucket cert with `SSL peer certificate or SSH remote key was not OK`, so feed snapshots / eat clips were captured and staged in `/tmp` but every PUT failed — while the non-verifying devlog path kept working. Two root causes, both fixed in the fork:

1. This old curl/openssl matches the connect host against CN and **DNS**-type SANs and does not reliably match an **IP literal** against an `iPAddress` SAN. The device connects to the bucket by IP (`10.40.0.33`), so an IP-only SAN failed `verifyhost`. Now each IP is added as **both** an `IPAddress` and a `DNSName` SAN.
2. The self-signed cert had no `basicConstraints`, so it was not a valid trust anchor for strict verifiers. Now `CA:TRUE` + `keyUsage(keyCertSign)` + SKI/AKI.

Also forces cert regeneration when the existing cert is not a CA (replaces the stale PVC cert on upgrade). After deploy, the `cacert` patch is re-applied so the device trusts the regenerated cert.