### PR TITLE
chore(petkit-local): bump fork build to v1.6.0-nkl.10

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.9"
+  default = "v1.6.0-nkl.10"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps petkit-local fork build to **v1.6.0-nkl.10**: feed-total counters (aggregate feedState.times/realAmountTotal from feed_over events), Feed Sound remap (D4H soundEnable), and cacert bundle dedup (strip prior copies of our cert before appending, fixing the duplicate-CN collision that broke media uploads under OpenSSL 1.0.0; re-apply now idempotent).