### PR TITLE
chore(petkit-local): bump fork build to v1.6.0-nkl.11 (Food Low fix)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.10"
+  default = "v1.6.0-nkl.11"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps petkit-local fork build to **v1.6.0-nkl.11**: fixes the "Food Low" binary_sensor reading the device `food` field backwards — the D4H reports `food=2` when the hopper is FULL, so the generic truthy template flagged a full hopper as Food Low. Now derives `state.foodLow` (low only when `food==0`).