### PR TITLE
chore(petkit-local): bump fork build to v1.6.0-nkl.12 (persist feed counters)

### DIFF
--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream (it did, once). Bump this by hand when
   // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.11"
+  default = "v1.6.0-nkl.12"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Bumps petkit-local fork build to **v1.6.0-nkl.12**: persists `feedState` (Times/Total Dispensed) via `Device.to_dict`/`from_dict` so the running daily totals survive pod restarts/deploys instead of resetting to zero mid-day. Live telemetry stays excluded from persistence; the day-rollover check still re-zeros on a real day change.