### PR TITLE
fix(hms-cpap): bump to v4.9.9-nkl.2 (sleep-day lookup on SQLite/MySQL)

### DIFF
--- a/apps/hms-cpap/docker-bake.hcl
+++ b/apps/hms-cpap/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 4.9.9-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream. Bump this by hand when cutting a new
   // fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v4.9.9-nkl.1"
+  default = "v4.9.9-nkl.2"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
getSessionStartForSleepDay was a nullopt stub outside PostgreSQL, so the
LLM summary and force-complete endpoints never worked on SQLite/MySQL
deployments.
