### PR TITLE
fix(hms-cpap): bump to v4.9.9-nkl.3

### DIFF
--- a/apps/hms-cpap/docker-bake.hcl
+++ b/apps/hms-cpap/docker-bake.hcl
@@ -10,7 +10,7 @@ variable "VERSION" {
   // the 4.9.9-nkl.N fork prereleases, so a renovate rule here "upgrades" us
   // straight back to unpatched upstream. Bump this by hand when cutting a new
   // fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v4.9.9-nkl.2"
+  default = "v4.9.9-nkl.3"
 }
 
 variable "SOURCE" {


### PR DESCRIPTION
Preserves the requested sleep day when generating a historical AI summary. v4.9.9-nkl.2 fixed SQLite/MySQL session lookup but still saved the result under the current date.