### PR TITLE
feat(petkit-local): switch to upstream alex-so-3 v2.1.0

### DIFF
--- a/apps/petkit-local/Dockerfile
+++ b/apps/petkit-local/Dockerfile
@@ -18,12 +18,13 @@ WORKDIR /opt/petkit-local
 
 # ffmpeg remuxes device camera clips; go2rtc republishes the camera stream as
 # RTSP. Both degrade gracefully on camera-less devices.
-# Built from nklmilojevic/petkit-local (fork of alex-so-3/petkit-local) at tag
-# ${VERSION}, which carries the D4H fixes (Ingenic BLE provisioning + camera
-# feeder IP). Upstream PRs are open; revert SOURCE/VERSION to alex-so-3 once
-# they merge. The GitHub tag archive extracts to petkit-local-${VERSION#v}/.
+# Built from upstream alex-so-3/petkit-local at tag ${VERSION}. The fork-era
+# D4H fixes (BLE provisioning, camera feeder IP, desiccant countdown, feed-clip
+# upload chain, cameraMultiNew schedule objects, bucket-cert SAN, feed totals,
+# feedSound, cacert dedup) all landed upstream by v2.1.0. The GitHub tag
+# archive extracts to petkit-local-${VERSION#v}/.
 RUN apk add --no-cache catatonit ffmpeg \
-    && wget -qO- "https://github.com/nklmilojevic/petkit-local/archive/refs/tags/${VERSION}.tar.gz" | tar xz -C /tmp \
+    && wget -qO- "https://github.com/alex-so-3/petkit-local/archive/refs/tags/${VERSION}.tar.gz" | tar xz -C /tmp \
     && pip install -r "/tmp/petkit-local-${VERSION#v}/addon/requirements.txt" \
     && cp -r "/tmp/petkit-local-${VERSION#v}/addon/petkit_local" ./petkit_local \
     && rm -rf "/tmp/petkit-local-${VERSION#v}" \

--- a/apps/petkit-local/docker-bake.hcl
+++ b/apps/petkit-local/docker-bake.hcl
@@ -5,16 +5,12 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  // Pinned by hand — renovate intentionally does NOT manage this. The fork
-  // still carries upstream's plain `v1.6.0` tag, and semver ranks 1.6.0 ABOVE
-  // the 1.6.0-nkl.N fork prereleases, so a renovate rule here "upgrades" us
-  // straight back to unpatched upstream (it did, once). Bump this by hand when
-  // cutting a new fork tag; drop the fork entirely once the fixes land upstream.
-  default = "v1.6.0-nkl.12"
+  // renovate: datasource=github-releases depName=alex-so-3/petkit-local
+  default = "v2.1.0"
 }
 
 variable "SOURCE" {
-  default = "https://github.com/nklmilojevic/petkit-local"
+  default = "https://github.com/alex-so-3/petkit-local"
 }
 
 group "default" {


### PR DESCRIPTION
## Summary
- Retire the `nklmilojevic/petkit-local` fork: every D4H fix it carried landed upstream by v2.1.0 — BLE provisioning (upstream #11), camera feeder IP (#12), desiccant countdown, feed-clip upload chain (cloud-storage block + feedPicture/eatVideo/upload seeding), cameraMultiNew schedule objects, bucket-cert SAN, feed-total counters, feedSound, cacert bundle dedup.
- `SOURCE`/tarball URL back to `alex-so-3/petkit-local`, `VERSION=v2.1.0`.
- Renovate management of `VERSION` restored (safe again — no more prerelease fork tags for semver to rank below upstream).

Known gaps vs the fork, accepted: D4H `food_low` is still inverted upstream (no real D4H capture there; nkl.11 derived `foodLow`), feed totals reset on restart (nkl.12 persisted them), `battery_installed` removed rather than derived.

## Test plan
- [x] `just local-build petkit-local` — image builds, testcontainers HTTP check on 8099 passes
- [x] Ran image with production args (`--api-url --mqtt-tls --mqtt-tls-port=8443 …`): API `/6/` answers, MQTT TLS 8443, HTTPS bucket 9000, cert generated